### PR TITLE
fix: rarible address encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ try {
     executingClientProfileId,
     mirrorerProfileId,
     mirrorPubId,
+    sourceUrl,
   });
 } catch (error) {
   console.log(error);
@@ -166,14 +167,16 @@ interface IPlatformService {
     signature: string,
     contract: string,
     tokenId: bigint,
-    dstChainId: bigint
+    dstChainId: bigint,
+    sourceUrl?: string
   ): Promise<UIData | undefined>;
   getPrice(
     contractAddress: string,
     nftId: bigint,
     signature: string,
     userAddress: string,
-    unit?: bigint
+    unit?: bigint,
+    sourceUrl?: string
   ): Promise<bigint | undefined>;
   getArgs(
     contractAddress: string,
@@ -182,7 +185,8 @@ interface IPlatformService {
     signature: string,
     price: bigint,
     quantity: bigint,
-    profileOwnerAddress: string
+    profileOwnerAddress: string,
+    sourceUrl?: string
   ): Promise<any[]>;
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nft-openaction-kit",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Seamless integration of NFT platforms into the Lens protocol by enabling automatic detection and handling of NFT links within Lens publications.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/DetectionEngine.ts
+++ b/src/DetectionEngine.ts
@@ -17,7 +17,10 @@ import { IDetectionEngine } from "./interfaces/IDetectionEngine";
 import { IPlatformService } from "./interfaces/IPlatformService";
 import { ArtBlocksService } from "./platform/ArtBlocksService";
 import { OpenSeaService } from "./platform/OpenSeaService";
-import { RaribleService } from "./platform/RaribleService";
+import {
+  RARIBLE_MINTER_ADDRESS,
+  RaribleService,
+} from "./platform/RaribleService";
 import {
   PODS_CHAIN_ID_MAPPING,
   PodsService,
@@ -221,6 +224,9 @@ export class DetectionEngine implements IDetectionEngine {
             const isPolygon = url.includes("/token/polygon/");
             const chain = isPolygon ? polygon : mainnet;
             const contractAddress = match[1];
+            const minterAddress = isPolygon
+              ? RARIBLE_MINTER_ADDRESS["POLYGON"]
+              : RARIBLE_MINTER_ADDRESS["ETHEREUM"];
             const nftId = match[2];
 
             // Return undefined for unsupported chains (Rari Chain, ZkSync Era, Immutable X)
@@ -232,6 +238,7 @@ export class DetectionEngine implements IDetectionEngine {
               platform: this.nftPlatformConfig["Rarible"],
               chain: chain,
               contractAddress,
+              minterAddress,
               nftId,
               service: new RaribleService({
                 chain,

--- a/src/interfaces/INftOpenActionKit.ts
+++ b/src/interfaces/INftOpenActionKit.ts
@@ -16,6 +16,7 @@ export interface ActionDataFromPostParams {
   executingClientProfileId: string;
   mirrorerProfileId?: string;
   mirrorPubId?: string;
+  sourceUrl?: string;
 }
 
 export interface INftOpenActionKit {
@@ -35,6 +36,7 @@ export interface INftOpenActionKit {
     mirrorerProfileId,
     mirrorPubId,
     executingClientProfileId,
+    sourceUrl,
   }: ActionDataFromPostParams): Promise<ActionData>;
 
   generateUiData({ contentURI }: { contentURI: string }): Promise<UIData>;

--- a/src/interfaces/IPlatformService.ts
+++ b/src/interfaces/IPlatformService.ts
@@ -19,14 +19,16 @@ export interface IPlatformService {
     signature: string,
     contract: string,
     tokenId: bigint,
-    dstChainId: bigint
+    dstChainId: bigint,
+    sourceUrl?: string
   ): Promise<UIData | undefined>;
   getPrice(
     contractAddress: string,
     nftId: bigint,
     signature: string,
     userAddress: string,
-    unit?: bigint
+    unit?: bigint,
+    sourceUrl?: string
   ): Promise<bigint | undefined>;
   getArgs(
     contractAddress: string,
@@ -35,6 +37,7 @@ export interface IPlatformService {
     signature: string,
     price: bigint,
     quantity: bigint,
-    profileOwnerAddress: string
+    profileOwnerAddress: string,
+    sourceUrl?: string
   ): Promise<any[]>;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,7 @@ export type NFTPlatform = {
 export type NFTExtraction<TChain extends Chain = Chain> = {
   chain: TChain;
   contractAddress: string;
+  minterAddress?: string;
   nftId: string;
   service: IPlatformService;
 };


### PR DESCRIPTION
Address that needs to be encoded for Rarible actions is minter address in place of nft address, however directly replacing with minter address in all places breaks ui methods.

This PR encodes the minter address in initialize data, and allows nft address to be passed through sourceUrl