### PR TITLE
feat: update polygon contract deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nft-openaction-kit",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Seamless integration of NFT platforms into the Lens protocol by enabling automatic detection and handling of NFT links within Lens publications.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,7 +5,7 @@ export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export const CHAIN_CONFIG: ChainConfig = {
   lensHubProxyAddress: "0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d",
-  decentOpenActionContractAddress: "0x1525B2a2093E700e17E2749536237C01fE4B4e20",
+  decentOpenActionContractAddress: "0x028f6aeE3CF9e1cA725f4C47d9460801b6c7508A",
 };
 
 export const DESTINATION_CHAINS = [


### PR DESCRIPTION
Contract update to use `transactionExecutor` in place of `oaInstructions.from` to remove condition preventing certain txns from working with relayer.