### PR TITLE
fix: timeout on IPFS request

### DIFF
--- a/src/platform/ZoraService.ts
+++ b/src/platform/ZoraService.ts
@@ -15,6 +15,7 @@ import MetadataRendererABI from "../config/abis/Zora/MetadataRenderer.json";
 import ZoraCreator1155ImplABI from "../config/abis/Zora/ZoraCreator1155Impl.json";
 import ZoraCreatorFixedPriceSaleStrategyABI from "../config/abis/Zora/ZoraCreatorFixedPriceSaleStrategy.json";
 import { NFTExtraction, ServiceConfig, UIData } from "../types";
+import { fetchIPFSMetadataImageWithFallback } from "../utils";
 
 type Sale = {
   saleStart: number;
@@ -150,11 +151,7 @@ export class ZoraService implements IPlatformService {
 
       const uri = (await erc1155Contract.read.uri([tokenId])) as string;
       const cid = uri.split("/").pop();
-      const response = await fetch(
-        `https://ipfs.decentralized-content.com/ipfs/${cid}`
-      );
-      const metadata: any = await response.json();
-      nftUri = metadata.image;
+      nftUri = await fetchIPFSMetadataImageWithFallback(cid);
     } else {
       const erc721DropContract = getContract({
         address: contract as `0x${string}`,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,3 +23,44 @@ export const idToChain = (id: number): Chain => {
     id: id as any,
   });
 };
+
+export const fetchIPFSMetadataImageWithFallback = async (
+  cid: string | undefined
+): Promise<string> => {
+  if (!cid) return "";
+
+  const gateway = `https://ipfs.decentralized-content.com/ipfs/${cid}`;
+
+  try {
+    const response = await fetchWithTimeout(gateway, 3000);
+    if (response.ok) {
+      const metadata: any = await response.json();
+      return metadata.image || "";
+    }
+  } catch (error) {
+    console.warn(`Error fetching from ${gateway}: ${error}`);
+  }
+
+  return "";
+};
+
+export const fetchWithTimeout = (
+  url: string,
+  timeout: number
+): Promise<Response> => {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("Request timed out")),
+      timeout
+    );
+    fetch(url)
+      .then((response) => {
+        clearTimeout(timer);
+        resolve(response);
+      })
+      .catch((err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+  });
+};


### PR DESCRIPTION
This PR adds a timeout to IPFS media calls, in case media isn't pinned anymore.
Timeout now set to 3 seconds.