### PR TITLE
fix: disable patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nft-openaction-kit",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Seamless integration of NFT platforms into the Lens protocol by enabling automatic detection and handling of NFT links within Lens publications.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/DetectionEngine.ts
+++ b/src/DetectionEngine.ts
@@ -1,7 +1,4 @@
-import {
-  Chain,
-  mainnet,
-} from "viem/chains";
+import { Chain, mainnet } from "viem/chains";
 import {
   NFTExtraction,
   NftPlatformConfig,
@@ -116,7 +113,7 @@ export class DetectionEngine implements IDetectionEngine {
       platformService: ArtBlocksService,
     }; */
 
-    this.nftPlatformConfig.SuperRare = {
+    /*     this.nftPlatformConfig.SuperRare = {
       platformName: "SuperRare",
       platformLogoUrl: "https://superrare.com/favicon.ico",
       urlPattern:
@@ -152,7 +149,7 @@ export class DetectionEngine implements IDetectionEngine {
         return Promise.resolve(undefined);
       },
       platformService: SuperRareService,
-    };
+    }; */
 
     this.nftPlatformConfig.Pods = {
       platformName: "Pods",

--- a/src/platform/ZoraService.ts
+++ b/src/platform/ZoraService.ts
@@ -357,8 +357,7 @@ export class ZoraService implements IPlatformService {
   ): boolean {
     // check the saleEnd + mint liquidity available
     const now = Math.floor(Date.now() / 1000);
-    const saleOpen =
-      saleStart <= now && (Number(saleEnd) === 0 || saleEnd >= now);
+    const saleOpen = saleStart <= now && saleEnd >= now;
     const quantityAvailable = maxSupply > totalMinted;
     return saleOpen && quantityAvailable;
   }


### PR DESCRIPTION
- Disable SuperRare detection engine to investigate conditions where NFTs are supported and not supported
- Remove one line exception added for Zora that allowed NFTs with ERC20 mint status to be posted, but it is removed since these NFTs are not yet able to be executed