### PR TITLE
chore: revert zora mint reward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nft-openaction-kit
 
+## 1.0.31
+
+### Patch Changes
+
+- Revert Zora mint reward to 0.000777
+
 ## 1.0.30
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nft-openaction-kit",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Seamless integration of NFT platforms into the Lens protocol by enabling automatic detection and handling of NFT links within Lens publications.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/platform/ZoraService.ts
+++ b/src/platform/ZoraService.ts
@@ -288,6 +288,6 @@ export class ZoraService implements IPlatformService {
   private getFees(): bigint {
     // Minting fees
     // https://support.zora.co/en/articles/4981037-zora-mint-collect-fees
-    return parseEther("0.000111");
+    return parseEther("0.000777");
   }
 }


### PR DESCRIPTION
[Zora docs](https://support.zora.co/en/articles/1368513) claim that min rewards are updated to 0.000111, but this isn't reflected in all NFT releases (https://zora.co/collect/zora:0x7454752ebaa91f46b2095aa3deb72310be93ea67/41 for example)