### PR TITLE
feat: return raw metadata URI as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ type UIData = {
   nftCreatorAddress?: string;
   tokenStandard: string;
   dstChainId: number;
+  rawMetadataUri?: string;
   zoraAdditional?: ZoraAdditional;
   podsAdditional?: PodsAdditional;
 };

--- a/src/platform/PodsService.ts
+++ b/src/platform/PodsService.ts
@@ -152,6 +152,7 @@ export class PodsService implements IPlatformService {
         nftName: await podcastContract.read.name(),
         nftUri: response.image,
         nftCreatorAddress: await podcastContract.read.owner(),
+        rawMetadataUri: metadataURI,
         tokenStandard: "erc1155",
         dstChainId: Number(dstChainId),
         podsAdditional: response,

--- a/src/platform/ZoraService.ts
+++ b/src/platform/ZoraService.ts
@@ -163,6 +163,7 @@ export class ZoraService implements IPlatformService {
         platformLogoUrl: this.platformLogoUrl,
         nftName,
         nftUri: response.image,
+        rawMetadataUri: uri,
         nftCreatorAddress,
         tokenStandard: this.isERC1155(signature) ? "erc1155" : "erc721",
         dstChainId: Number(dstChainId),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,7 @@ export type UIData = {
   nftCreatorAddress?: string;
   tokenStandard: string;
   dstChainId: number;
+  rawMetadataUri?: string;
   zoraAdditional?: ZoraAdditional;
   podsAdditional?: PodsAdditional;
 };


### PR DESCRIPTION
The nftURI and additional metadata are returned by querying an IPFS gateway for underlying NFT URI.

The library implements a fallback gateway but in case this fails (for CORS or gateway errors within the library), return the `rawMetadataURI` which apps can use to query all metadata themselves